### PR TITLE
UrisFactory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,5 @@ fabric.properties
 .idea/caches/build_file_checksums.ser
 
 run.py
+
+venv/

--- a/wbsync/external/uri_factory.py
+++ b/wbsync/external/uri_factory.py
@@ -3,36 +3,39 @@
 import pickle
 import os
 from abc import ABC, abstractmethod
+from typing import Union
+from ..triplestore import URIElement, AnonymousElement
 
 URIS_FILE = os.path.join(os.getcwd(), 'uris.pkl')
+NonLiteralElement = Union[URIElement, AnonymousElement]
 
 class URIFactory(ABC):
 
     @abstractmethod
-    def get_uri(self, label) -> str:
+    def get_uri(self, uriRef:NonLiteralElement) -> str:
         """ Gets the uri for a label.
 
        Parameters
        ----------
-       str: label
-           Label to find a uri.
+       NonLiteralElement: uriRef
+           NonLiteralElement to find a uri.
 
        Returns
        -------
        :str: uri
-           Uri that corresponds to the label
+           Uri that corresponds to the NonLiteralElement
        """
 
     @abstractmethod
-    def post_uri(self, label, wb_uri) -> None:
+    def post_uri(self, uriRef:NonLiteralElement, wb_uri) -> None:
         """ Posts the uri for a label.
 
           Parameters
           ----------
-          str: label
-              Label that corresponds to the new uri.
+          NonLiteralElement: uriRef
+              NonLiteralElement that corresponds to the new uri.
 
-          wb_uri: label
+          wb_uri: str
               Uri for the label .
           """
 
@@ -56,12 +59,12 @@ class URIFactoryMock(URIFactory):
             URIFactoryMock.instance = URIFactoryMock.__URIFactoryMock()
 
 
-    def get_uri(self, label):
-        return URIFactoryMock.instance.state[label] \
-            if label in URIFactoryMock.instance.state else None
+    def get_uri(self, uriRef:NonLiteralElement):
+        return URIFactoryMock.instance.state[uriRef.uri] \
+            if uriRef.uri in URIFactoryMock.instance.state else None
 
-    def post_uri(self, label, wb_uri):
-        URIFactoryMock.instance.state[label] = wb_uri
+    def post_uri(self, uriRef:NonLiteralElement, wb_uri):
+        URIFactoryMock.instance.state[uriRef.uri] = wb_uri
         with open(URIS_FILE, 'wb') as f:
             pickle.dump(URIFactoryMock.instance.state, f)
 

--- a/wbsync/external/uri_factory.py
+++ b/wbsync/external/uri_factory.py
@@ -3,17 +3,14 @@
 import pickle
 import os
 from abc import ABC, abstractmethod
-from typing import Union
-from ..triplestore import URIElement, AnonymousElement
 
 URIS_FILE = os.path.join(os.getcwd(), 'uris.pkl')
-NonLiteralElement = Union[URIElement, AnonymousElement]
 
 class URIFactory(ABC):
 
     @abstractmethod
-    def get_uri(self, uriRef:NonLiteralElement) -> str:
-        """ Gets the uri for a label.
+    def get_uri(self, uriRef) -> str:
+        """ Gets the uri for a NonLiteralElement.
 
        Parameters
        ----------
@@ -27,8 +24,8 @@ class URIFactory(ABC):
        """
 
     @abstractmethod
-    def post_uri(self, uriRef:NonLiteralElement, wb_uri) -> None:
-        """ Posts the uri for a label.
+    def post_uri(self, uriRef, wb_uri) -> None:
+        """ Posts the uri for a NonLiteralElement.
 
           Parameters
           ----------
@@ -59,11 +56,11 @@ class URIFactoryMock(URIFactory):
             URIFactoryMock.instance = URIFactoryMock.__URIFactoryMock()
 
 
-    def get_uri(self, uriRef:NonLiteralElement):
+    def get_uri(self, uriRef):
         return URIFactoryMock.instance.state[uriRef.uri] \
             if uriRef.uri in URIFactoryMock.instance.state else None
 
-    def post_uri(self, uriRef:NonLiteralElement, wb_uri):
+    def post_uri(self, uriRef, wb_uri):
         URIFactoryMock.instance.state[uriRef.uri] = wb_uri
         with open(URIS_FILE, 'wb') as f:
             pickle.dump(URIFactoryMock.instance.state, f)

--- a/wbsync/triplestore/wikibase_adapter.py
+++ b/wbsync/triplestore/wikibase_adapter.py
@@ -219,7 +219,7 @@ class WikibaseAdapter(TripleStoreManager):
         return rel_link_prop_id
 
     def _get_wb_id_of(self, uriref: NonLiteralElement, proptype: str):
-        wb_uri = uris_factory.get_uri(uriref.uri) #factory
+        wb_uri = uris_factory.get_uri(uriref) #factory
         if wb_uri is not None:
             logging.debug("Id of %s in wikibase: %s", uriref, wb_uri)
             return wb_uri
@@ -229,7 +229,7 @@ class WikibaseAdapter(TripleStoreManager):
         entity_id = modification_result.result
 
         # update uri factory with new item
-        uris_factory.post_uri(uriref.uri, entity_id) #factory
+        uris_factory.post_uri(uriref, entity_id) #factory
         return entity_id
 
     def _init_callbacks(self):


### PR DESCRIPTION
* The new UriFactory interface defines the same methods as before but now these methods receive a NonLiteralElement instead of a label. This allows the UriFactory instances to get more info about the element before posting or getting its URI